### PR TITLE
feat: 동일한 유저로 같은 특강 신청했을 때 1번만 성공하도록 동시성 처리

### DIFF
--- a/src/main/java/com/example/hhpluslecture/common/ErrorMessage.java
+++ b/src/main/java/com/example/hhpluslecture/common/ErrorMessage.java
@@ -13,6 +13,7 @@ public enum ErrorMessage {
 	NO_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력 값이 없습니다."),
 	LECTURE_DATE_FORM_ERROR(HttpStatus.BAD_REQUEST, "YYYYMMDD 형태로 입력해주세요."),
 	CANT_ENROLL_LECTURE(HttpStatus.BAD_REQUEST, "30명 정원 초과 하였습니다."),
+	DUPLICATE_ENROLL_LECTURE(HttpStatus.BAD_REQUEST, "이미 신청 하였습니다."),
 	DUMMY(null, "");
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/example/hhpluslecture/enrollCourse/facade/EnrollCourseFacade.java
+++ b/src/main/java/com/example/hhpluslecture/enrollCourse/facade/EnrollCourseFacade.java
@@ -1,10 +1,13 @@
 package com.example.hhpluslecture.enrollCourse.facade;
 
+import static com.example.hhpluslecture.common.ErrorMessage.*;
+
 import java.util.List;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.hhpluslecture.common.CustomException;
 import com.example.hhpluslecture.enrollCourse.dto.EnrollAvailableRequest;
 import com.example.hhpluslecture.enrollCourse.dto.EnrollAvailableResponse;
 import com.example.hhpluslecture.enrollCourse.dto.EnrollCompleteResponse;
@@ -42,6 +45,13 @@ public class EnrollCourseFacade {
 	public EnrollCourseResponse saveEnrollCourse(final EnrollCourseRequest enrollCourseRequest) {
 		Lecture lecture = getLectureById(enrollCourseRequest.lectureId());
 
+		EnrollCourse enrollCourse = getEnrollCourseById(enrollCourseRequest.studentId(),
+			enrollCourseRequest.lectureId());
+
+		if (enrollCourse != null) {
+			throw new CustomException(DUPLICATE_ENROLL_LECTURE);
+		}
+
 		validationService.saveEnrollValidation(enrollCourseRequest, lecture.getEnrollCount());
 
 		EnrollCourse newEnrollCourse = enrollCourseService.saveEnrollCourse(enrollCourseRequest);
@@ -50,9 +60,13 @@ public class EnrollCourseFacade {
 
 		return EnrollCourseResponse.of(newEnrollCourse.getEnrollCourseId());
 	}
-	
+
 	public Lecture getLectureById(final Long lectureId) {
 		return enrollCourseService.getLectureById(lectureId);
+	}
+
+	public EnrollCourse getEnrollCourseById(final Long studentId, final Long lectureId) {
+		return enrollCourseService.getEnrollCourseById(studentId, lectureId);
 	}
 
 }

--- a/src/main/java/com/example/hhpluslecture/enrollCourse/repository/EnrollCourseRepository.java
+++ b/src/main/java/com/example/hhpluslecture/enrollCourse/repository/EnrollCourseRepository.java
@@ -11,4 +11,7 @@ public interface EnrollCourseRepository extends JpaRepository<EnrollCourse, Long
 
 	@Query("SELECT ec FROM EnrollCourse ec INNER JOIN ec.student s WHERE s.studentId = :studentId")
 	List<EnrollCourse> findByStudentId(final Long studentId);
+
+	@Query("SELECT ec FROM EnrollCourse ec WHERE ec.studentId = :studentId AND ec.lectureId = :lectureId")
+	EnrollCourse findByStudentIdAndLectureId(final Long studentId, final Long lectureId);
 }

--- a/src/main/java/com/example/hhpluslecture/enrollCourse/service/EnrollCourseService.java
+++ b/src/main/java/com/example/hhpluslecture/enrollCourse/service/EnrollCourseService.java
@@ -38,4 +38,9 @@ public class EnrollCourseService {
 	public Lecture getLectureById(final Long lectureId) {
 		return lectureRepository.findByLectureId(lectureId);
 	}
+
+	public EnrollCourse getEnrollCourseById(final Long studentId, final Long lectureId) {
+		return enrollCourseRepository.findByStudentIdAndLectureId(studentId, lectureId);
+	}
+
 }


### PR DESCRIPTION
### **커밋 링크**
<!--
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

feat: 동일한 유저로 같은 특강 신청했을 때 1번만 성공하도록 동시성 처리: 2ebea5172058c6a3457ba9ac45414af294f99194


---
### **리뷰 포인트(질문)**
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)

  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->

특강 신청 1번만 되도록 동시성 처리 2가지 방법
1. enroll_course 테이블에 (student_id, lecture_id)에 unique를 걸어 준다. (DB로 해결)
2. studentId와 lectureId and 조건으로 검색하여 find 한다음 해당 Object가 존재하면 에러를 던지게 처리 한다. (코드 로직으로 해결)

---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->

### Problem
<!--개선이 필요한 점-->

### Try
<!-- 새롭게 시도할 점 -->
